### PR TITLE
Snailtrail 2019

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Andrea Lattuada <andrea.lattuada@inf.ethz.ch>
 Desislava Dimitrova <dimitrova@inf.ethz.ch>
 Frank McSherry <fmcsherry@me.com>
 John Liagouris <liagos@inf.ethz.ch>
+Malte Sandstede <samalt@ethz.ch>
 Moritz Hoffmann <moritzho@inf.ethz.ch>
 Ralf Sager <rsa@3fnc.org>
 Sebastian Wicki <swicki@inf.ethz.ch>

--- a/logformat/rust/Cargo.toml
+++ b/logformat/rust/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "logformat"
-version = "0.1.0"
+version = "0.2.0"
+edition = "2018"
+description = "definitions for data types used to serialize raw traces"
 
 [dependencies]
 rmp = "^0.8"
 enum-primitive-derive = "^0.1"
-num-traits = "^0.1"
-abomonation = "0.4"
+num-traits = "^0.2"
+abomonation = "0.7"
+abomonation_derive = "0.3"
+# @TODO: replace with serde
 json = "0.11.12"
-abomonation_derive = "0.2.3"
-clap = "^2.29"
+clap = "^2.32"
 
 [dev-dependencies]
-rmp-serde = "0.13.7"
-serde = "1.0"
-serde_derive = "1.0"
-quick-protobuf = "0.6.0"
-byteorder = "1.2"
-protobuf = "1.4.3"
-
+rmp-serde = "^0.13"
+quick-protobuf = "^0.6"
+serde = { version = "1.0", features = ["derive"] }
+# serde_json = "1.0"
+# protobuf = "1.4.3" necessary?
+byteorder = "^1.2"

--- a/logformat/rust/src/bin/cpviz.rs
+++ b/logformat/rust/src/bin/cpviz.rs
@@ -6,10 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate logformat;
 #[macro_use]
 extern crate json;
-extern crate clap;
 
 use std::fs::File;
 use std::io::{Result, BufReader, BufWriter, Write};

--- a/logformat/rust/src/lib.rs
+++ b/logformat/rust/src/lib.rs
@@ -9,11 +9,8 @@
 ///! Data structure and (de)serialization for a `LogRecord`
 
 
-extern crate rmp as msgpack;
 #[macro_use]
 extern crate enum_primitive_derive;
-extern crate num_traits;
-extern crate abomonation;
 #[macro_use]
 extern crate abomonation_derive;
 
@@ -21,6 +18,7 @@ use std::io::{Write, Read};
 use num_traits::{FromPrimitive, ToPrimitive};
 
 use msgpack::decode::NumValueReadError;
+use rmp as msgpack;
 
 #[derive(Primitive, Abomonation, PartialEq, Debug, Clone, Copy, Hash, Eq, PartialOrd, Ord)]
 pub enum ActivityType {

--- a/pag-construction/Cargo.toml
+++ b/pag-construction/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "pag-construction"
-version = "0.1.0"
+version = "0.2.0"
+edition = "2018"
 
 [dependencies]
-abomonation = "0.4"
+abomonation = "0.7"
+abomonation_derive = "0.3"
 clap = "*"
 time = "*"
-timely = "^0.3"
-timely_communication = "0.1.8"
-logformat = { version = "0.1.0", path = "../logformat/rust" }
-snailtrail = { version = "0.1.0", path = "../snailtrail" }
-abomonation_derive = "0.2.3"
+timely = "^0.9"
+logformat = { version = "0.2.0", path = "../logformat/rust" }
+snailtrail = { version = "0.2.0", path = "../snailtrail" }
 rand = "*"
-rayon = "^0.9.0"
+rayon = "^1.0"
 svg = "^0.5.7"

--- a/pag-construction/src/bin/construct.rs
+++ b/pag-construction/src/bin/construct.rs
@@ -6,17 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate clap;
-extern crate logformat;
-extern crate pag_construction;
-extern crate abomonation;
-extern crate rand;
-extern crate time;
-extern crate timely;
-extern crate timely_communication;
-
-extern crate snailtrail;
-
 use std::str::FromStr;
 
 use clap::{App, Arg};

--- a/snailtrail/Cargo.toml
+++ b/snailtrail/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "snailtrail"
-version = "0.1.0"
+version = "0.2.0"
+edition = "2018"
 
 [dependencies]
-abomonation = "^0.4"
+abomonation = "^0.7"
+# @TODO: replace with chrono
 time = "^0.1"
-timely = "0.3.0"
-rand = "^0.3"
-
+timely = "^0.9"
+rand = "^0.6"

--- a/snailtrail/src/exploration/single_path.rs
+++ b/snailtrail/src/exploration/single_path.rs
@@ -7,29 +7,27 @@
 // except according to those terms.
 
 use std;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::fmt::Debug;
-
-use timely::Data;
-use timely::dataflow::{Stream, Scope};
-use timely::dataflow::operators::*;
-
-use std::collections::HashMap;
-
-use graph::{SrcDst, Partitioning};
-use timely::progress::Timestamp;
-use timely::progress::nested::product::Product;
-use timely::dataflow::channels::pact::Exchange;
-
 use std::rc::Rc;
 
-use exploration::rand::{Rng, thread_rng};
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::*;
+use timely::dataflow::{Stream, Scope};
+use timely::order::Product;
+use timely::progress::Timestamp;
+use timely::Data;
+
+use crate::exploration::rand::prelude::SliceRandom;
+use crate::exploration::rand::thread_rng;
+use crate::graph::{Partitioning, SrcDst};
 
 
 pub trait ExtendedData: Data + Eq + Hash + Copy + Debug {}
 impl<T: Data + Eq + Hash + Copy + Debug> ExtendedData for T {}
 
-pub trait SinglePath<G: Scope, N: ExtendedData + Partitioning, D1: SrcDst<N> + Data + Eq + Hash>
+pub trait SinglePath<G: Scope, N: ExtendedData + Partitioning, D1: SrcDst<N> + Data + Eq + Hash + abomonation::Abomonation>
      {
     /// Traverses a path in a graph starting from a seed node.
     ///
@@ -41,7 +39,7 @@ pub trait SinglePath<G: Scope, N: ExtendedData + Partitioning, D1: SrcDst<N> + D
     fn single_path(&self, edge: &Stream<G, D1>) -> Stream<G, D1> where G::Timestamp: Hash + Copy;
 }
 
-impl<G: Scope, N: ExtendedData + Partitioning, D1: SrcDst<N> + Data + Eq + Hash + Debug + Send> SinglePath<G, N, D1> for Stream<G, D1> {
+impl<G: Scope, N: ExtendedData + Partitioning, D1: SrcDst<N> + Data + Eq + Hash + Debug + Send + std::marker::Sync + abomonation::Abomonation> SinglePath<G, N, D1> for Stream<G, D1> {
     fn single_path(&self, edge: &Stream<G, D1>) -> Stream<G, D1>
         where G::Timestamp: Hash+Copy
     {
@@ -50,9 +48,8 @@ impl<G: Scope, N: ExtendedData + Partitioning, D1: SrcDst<N> + Data + Eq + Hash 
 let graph_stream = self; //.concat(&forward_edges); //.concat(&backward_edges);
 
 // Traverse a transient path
-        let path = self.scope().scoped(|inner| {
-
-            let (helper, cycle) = inner.loop_variable(std::u32::MAX, 1);
+        self.scope().scoped("traversal", |inner| {
+            let (helper, cycle) = inner.loop_variable(1);
 
             let seed = edge.enter(inner).concat(&cycle);
 
@@ -60,7 +57,7 @@ let graph_stream = self; //.concat(&forward_edges); //.concat(&backward_edges);
 
             output.connect_loop(helper);
             output.leave()
-        });
+        })
 
 /*
         // Compute single-path summary
@@ -69,12 +66,10 @@ let graph_stream = self; //.concat(&forward_edges); //.concat(&backward_edges);
             |key, agg| { (key, agg.iter().sum()) },
             |key| hash_code(key));
         */
-
-path //.flat_map(|x| x.into_iter())
     }
 }
 
-pub trait TraverseFrom<G: Scope, D1: Data, K: Hash + Eq + Copy + Data + Partitioning + 'static>
+pub trait TraverseFrom<G: Scope, D1: Data + abomonation::Abomonation, K: Hash + Eq + Copy + Data + Partitioning + 'static>
      {
     /// Explores a graph iteratively based on a frontier stream.
     ///
@@ -97,7 +92,7 @@ pub trait TraverseFrom<G: Scope, D1: Data, K: Hash + Eq + Copy + Data + Partitio
 
 impl<TOuter: Timestamp,
      G: Scope<Timestamp = Product<TOuter, u32>>,
-     D1: Data + Debug + Hash + Eq + Send,
+     D1: Data + Debug + Hash + Eq + Send + std::marker::Sync + abomonation::Abomonation,
      K: Hash + Eq + Copy + Data + Partitioning + Debug + 'static> TraverseFrom<G, D1, K>
     for Stream<G, D1> {
     fn traverse_from<LG, LJ, TO, TS>(&self,
@@ -123,6 +118,8 @@ impl<TOuter: Timestamp,
         let join_exchange = join.clone();
         let exchange1 = Exchange::new(move |e| graph_exchange(e).partition());
         let exchange2 = Exchange::new(move |e| join_exchange(e).partition());
+        let mut vector1 = Vec::new();
+        let mut vector2 = Vec::new();
         self.binary_notify(seed,
                            exchange1,
                            exchange2,
@@ -130,24 +127,26 @@ impl<TOuter: Timestamp,
                            Vec::new(),
                            move |input1, input2, output, notificator| {
             // Pull graph edges
-            input1.for_each(|time, data| {
-                let key = snapshots.entry(*outer(&time)).or_insert_with(HashMap::new);
-                for d in data.drain(..) {
+            input1.for_each(|cap, data| {
+                let key = snapshots.entry(*outer(&cap)).or_insert_with(HashMap::new);
+                data.swap(&mut vector1);
+                for d in vector1.drain(..) {
                     let slot = key.entry(group(&d)).or_insert_with(Vec::new);
                     slot.push(d);
                 }
-                let mut cap = time.time().clone();
-                cap.inner = std::u32::MAX - 1;
-                notificator.notify_at(time.delayed(&cap));
-                notificator.notify_at(time.clone());
+                let mut time = cap.time().clone();
+                time.inner = std::u32::MAX - 1;
+                notificator.notify_at(cap.delayed(&time));
+                notificator.notify_at(cap.retain().clone());
             });
             // Pull edge seeds
             input2.for_each(|time, data| {
                                 let slot = seeds.entry(*outer(&time)).or_insert_with(Vec::new);
-                                for d in data.drain(..) {
+                data.swap(&mut vector2);
+                                for d in vector2.drain(..) {
                                     slot.push(d);
                                 }
-                                notificator.notify_at(time);
+                                notificator.notify_at(time.retain());
                             });
             notificator.for_each(|time, _count, _notificator| {
                 if time.time().inner < std::u32::MAX - 1 {
@@ -162,8 +161,9 @@ impl<TOuter: Timestamp,
                                 // Pick a next edge to visit at random
                                 if let Some(next_edges) = snapshot.get(&join(&seed)) {
                                     //.expect("No edges found.");
-                                    let next = thread_rng()
-                                        .choose(&next_edges[..])
+                                    let mut rng = thread_rng();
+                                    let next = next_edges[..]
+                                        .choose(&mut rng)
                                         .expect("No edges found")
                                         .clone(); //next_edges[0].clone();
                                     session.give(next);

--- a/snailtrail/src/exploration/single_path.rs
+++ b/snailtrail/src/exploration/single_path.rs
@@ -18,6 +18,7 @@ use timely::dataflow::{Stream, Scope};
 use timely::order::Product;
 use timely::progress::Timestamp;
 use timely::Data;
+use timely::ExchangeData;
 
 use crate::exploration::rand::prelude::SliceRandom;
 use crate::exploration::rand::thread_rng;
@@ -69,7 +70,7 @@ let graph_stream = self; //.concat(&forward_edges); //.concat(&backward_edges);
     }
 }
 
-pub trait TraverseFrom<G: Scope, D1: Data + abomonation::Abomonation, K: Hash + Eq + Copy + Data + Partitioning + 'static>
+pub trait TraverseFrom<G: Scope, D1: ExchangeData, K: Hash + Eq + Copy + Data + Partitioning + 'static>
      {
     /// Explores a graph iteratively based on a frontier stream.
     ///
@@ -92,7 +93,7 @@ pub trait TraverseFrom<G: Scope, D1: Data + abomonation::Abomonation, K: Hash + 
 
 impl<TOuter: Timestamp,
      G: Scope<Timestamp = Product<TOuter, u32>>,
-     D1: Data + Debug + Hash + Eq + Send + std::marker::Sync + abomonation::Abomonation,
+     D1: ExchangeData,
      K: Hash + Eq + Copy + Data + Partitioning + Debug + 'static> TraverseFrom<G, D1, K>
     for Stream<G, D1> {
     fn traverse_from<LG, LJ, TO, TS>(&self,

--- a/snailtrail/src/graph/mod.rs
+++ b/snailtrail/src/graph/mod.rs
@@ -25,7 +25,7 @@ pub trait SrcDst<N: Partitioning> {
 
 impl<N: Partitioning> Partitioning for Option<N> {
     fn partition(&self) -> u64 {
-        self.into_iter().map(|x| x.partition()).sum()
+        self.iter().map(Partitioning::partition).sum()
     }
 }
 

--- a/snailtrail/src/lib.rs
+++ b/snailtrail/src/lib.rs
@@ -36,8 +36,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use time;
 
-    use graph::{SrcDst, Partitioning};
-    use exploration::{UnboundCapacity, BetweennessCentrality};
+    use crate::graph::{SrcDst, Partitioning};
+    use crate::exploration::{UnboundCapacity, BetweennessCentrality};
 
     use timely;
     use timely::dataflow::operators::*;
@@ -80,8 +80,6 @@ mod tests {
     }
 
     unsafe_abomonate!(Edge: src, dst);
-
-    type Timestamp = u32;
 
     #[test]
     fn it_works() {
@@ -129,13 +127,13 @@ mod tests {
             let send = send.lock().unwrap().clone();
 
             let (mut graph_input, mut edge_input, mut edge_input2) =
-                root.dataflow::<Timestamp, _, _>(move |scope| {
+                root.dataflow(move |scope| {
 
                 let (graph_input, graph_stream) = scope.new_input();
                 let (edge_input, forward_stream) = scope.new_input();
                 let (edge_input2, backward_stream) = scope.new_input();
 
-                let result = graph_stream.betweenness_centrality::<UnboundCapacity, u64>(&forward_stream, &backward_stream, "comp");
+                let result = graph_stream.betweenness_centrality::<UnboundCapacity, _>(&forward_stream, &backward_stream, "comp");
                 // let result = result.inspect_batch(move |t, x| println!("[{:?}] {:?} -> {:?}", index, t, x));
                 result.capture_into(send);
                 let weight = result.map(|(edge, bc)| (edge, bc));

--- a/tensorflow/tensorflow-parser/Cargo.toml
+++ b/tensorflow/tensorflow-parser/Cargo.toml
@@ -10,5 +10,5 @@ log = "0.3.7"
 regex = "0.2.1"
 
 [dependencies.logformat]
-version = "0.1.0"
+version = "0.2.0"
 path = "../../logformat/rust"


### PR DESCRIPTION
This PR

- updates Rust to 2018 edition
- updates most of the dependencies used, in particular timely
- reformats using cargo fmt
- fixes linting errors highlighted by cargo clippy / Rust 2018

It does _not_ touch

- the python build scripts
- tensorflow / spark adapters

since I have severely pruned / removed them on my fork for now.